### PR TITLE
Dockerfile: Use "apt-get" instead of "apt"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:latest
 
 RUN apt-get -q update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" \
         python3 python3-pip python3-setuptools nginx supervisor
 
-#   DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends
-    
 RUN pip3 install uwsgi
 
 COPY ./requirements.txt /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:latest
 
 RUN apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
-        python3 python3-pip nginx supervisor
+        python3 python3-pip python3-setuptools nginx supervisor
 
 #   DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 
 RUN apt-get -q update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
+    DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" \
         python3 python3-pip python3-setuptools nginx supervisor
 
 #   DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:latest
 
-RUN apt update && \
-    apt install python3 python3-pip -y && \
-    apt install nginx supervisor -y 
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y \
+    -o Dpkg::Options::="--force-confnew" --no-install-recommends \
+    python3 python3-pip nginx supervisor
 
 RUN pip3 install uwsgi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:latest
 
 RUN apt-get -q update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
         python3 python3-pip nginx supervisor
 
+#   DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends
+    
 RUN pip3 install uwsgi
 
 COPY ./requirements.txt /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:latest
 
 RUN apt-get -q update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y \
-    -o Dpkg::Options::="--force-confnew" --no-install-recommends \
-    python3 python3-pip nginx supervisor
+    DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
+        python3 python3-pip nginx supervisor
 
 RUN pip3 install uwsgi
 


### PR DESCRIPTION
Prevents the following warning

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Fix https://github.com/hackafake/hackafake-backend/issues/32